### PR TITLE
Bugfix StringFilter

### DIFF
--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -25,6 +25,10 @@ class StringFilter extends Filter
             return;
         }
 
+        if (is_array($data['value'])) {
+            $data['value'] = array_shift($data['value']);
+        }
+
         $data['value'] = trim($data['value']);
 
         if (strlen($data['value']) == 0) {


### PR DESCRIPTION
Bugfix: Warning: trim() expects parameter 1 to be string, array given

Sample:

```
protected function configureDatagridFilters(DatagridMapper $filter)
{
    $filter
        ->add('name')
        ->add('region', null, [], 'choice', [
            'label' => 'label.cat.region',
            'choices' => Cat::$regions,
            'expanded' => true,
            'multiple' => true
        ])
    ;
}
```
